### PR TITLE
Potential fix for code scanning alert no. 3: Unsafe jQuery plugin

### DIFF
--- a/assets/js/plugins/jquery.magnific-popup.js
+++ b/assets/js/plugins/jquery.magnific-popup.js
@@ -14,6 +14,23 @@
    }
    }(function($) {
 
+  /**
+   * Sanitize markup to avoid script injection vulnerabilities.
+   * This basic sanitizer removes <script> tags and event handler attributes. 
+   * For applications that require user content, a stricter sanitizer should be used.
+   * @param {string} markup
+   * @returns {string} sanitized markup
+   */
+  function sanitizeMarkup(markup) {
+    if (typeof markup !== 'string') return markup;
+    // Remove <script>...</script> tags (greedy)
+    markup = markup.replace(/<script[\s\S]*?>[\s\S]*?<\/script\s*>/gi, '');
+    // Remove event handler attributes, e.g. onclick, onerror
+    markup = markup.replace(/\son\w+\s*=\s*(['"]).*?\1/gi, '');
+    // Optionally, you may want to do more.
+    return markup;
+  }
+
   /*>>core*/
   /**
    *
@@ -506,7 +523,12 @@
         _mfpTrigger('FirstMarkupParse', markup);
 
         if(markup) {
-          mfp.currTemplate[type] = $(markup);
+          /**
+           * SECURITY: The value for `markup` may originate from plugin options.
+           * If untrusted data is passed here, it could lead to XSS.
+           * Therefore, user-supplied `markup` must be trusted or properly sanitized!
+           */
+          mfp.currTemplate[type] = $(sanitizeMarkup(markup));
         } else {
           // if there is no markup found we just define that template is parsed
           mfp.currTemplate[type] = true;


### PR DESCRIPTION
Potential fix for [https://github.com/ashim888/ajna_blog/security/code-scanning/3](https://github.com/ashim888/ajna_blog/security/code-scanning/3)

The best way to fix this issue is to ensure that untrusted input for the `markup` option cannot lead to script injection via the `$()` HTML string parser. There are two general approaches:
1. Properly document the `markup` option, warning users that it must not be set based on unsanitized user input, and sanitize or escape it as necessary.
2. Programmatically check the `markup` string before passing it to `$()`, rejecting or sanitizing obviously-dangerous content (e.g., disallowing `<script>` tags or event-handler attributes), or allowing only intended templates.

For a robust fix, we should both document which options are potentially dangerous (i.e., require sanitization), **and** add programmatic checks to prevent dangerous usage. In this concrete file, the factual code fix would be to *reject or sanitize* the `markup` supplied via options before it is consumed at line 509.

**Implementation details:**
- Add a function before line 509 (or as a utility) that checks whether `markup` is safe (e.g., does not contain `<script` or `on*=` event handler attributes).
- Reject, sanitize, or escape if unsafe.
- Optionally, throw or log a warning if unsafe markup is detected.
- Additionally, add documentation/comments at the declaration of the plugin and at the location where `markup` is interpreted, advising plugin users of the requirement.

Since we are limited to only changing code we've seen (so only within assets/js/plugins/jquery.magnific-popup.js), we'll:
- Add a `sanitizeMarkup` helper.
- Use it at the vulnerable sink.
- Add clear JSDoc/comments near the assignment noting the risk and the plugin user's responsibility if relevant.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
